### PR TITLE
Fixing typo in communication major

### DIFF
--- a/app/Models/Major.php
+++ b/app/Models/Major.php
@@ -36,7 +36,7 @@ class Major extends Model
         'keleti nyelvek és kultúrák (török)',
         'keleti nyelvek és kultúrák (újgörög)',
         'kereskedelem és marketing',
-        'kommunikáció-és médiatudomány',
+        'kommunikáció- és médiatudomány',
         'kémia',
         'könyvtár/(informatikus)-könyvtáros',
         'környezettan',


### PR DESCRIPTION
`kommunikáció-és médiatudomány` became `kommunikáció- és médiatudomány` in the seeder. I'll merge this quickly.